### PR TITLE
Remove unnecessary global namespace import

### DIFF
--- a/Shadow_Bubble_Elite.py
+++ b/Shadow_Bubble_Elite.py
@@ -9,10 +9,9 @@ import time
 import re
 import curses
 import psutil
-import multiprocessing
-from multiprocessing import Process, Manager
+from multiprocessing import Process, Manager as MPManager
 
-manager = multiprocessing.Manager()
+manager = MPManager()
 process_registry = manager.list()
 activity_log = manager.list()
 selected_wifis = []


### PR DESCRIPTION
Removed unused naked import of `multiprocessing`

Imported multiprocessing.Manager as MPManager to preserve readability and avoid global namespace pollution